### PR TITLE
fix: trim environment variables

### DIFF
--- a/config/environment.ts
+++ b/config/environment.ts
@@ -31,14 +31,14 @@ export interface EnvironmentConfig {
 const getEnvironment = (): string => {
   // Check explicit environment variable first
   if (process.env.ENVIRONMENT) {
-    return process.env.ENVIRONMENT.toLowerCase();
+    return process.env.ENVIRONMENT.trim().toLowerCase();
   }
-  
+
   // Fall back to NODE_ENV
   if (process.env.NODE_ENV) {
-    return process.env.NODE_ENV.toLowerCase();
+    return process.env.NODE_ENV.trim().toLowerCase();
   }
-  
+
   // Default to development
   return 'development';
 };


### PR DESCRIPTION
## Summary
- trim whitespace from ENVIRONMENT and NODE_ENV before determining configuration

## Testing
- `npm run check` *(fails: sheets and notifications components have TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894b2d6222883228c5c1e4a29480c0e